### PR TITLE
Fix highlighting of option pragmas

### DIFF
--- a/grammars/agda.cson
+++ b/grammars/agda.cson
@@ -16,7 +16,7 @@
     'patterns': [
       {
         'name': 'comment.line.double-dash.agda'
-        'begin': '--'
+        'begin': '--(?!.*#-\}$)'
         'end': '\\n'
       }
       {


### PR DESCRIPTION
This prevents the highlighter from coloring everything below as comments due to double-dash in leading OPTIONS pragmas:

``` agda
{-# OPTIONS --without-K #-}
{-# OPTIONS --copatterns #-}
```

Prompted by @np.
