### PR TITLE
Add LaTeX based Literate Agda support

### DIFF
--- a/grammars/lagda.cson
+++ b/grammars/lagda.cson
@@ -1,207 +1,50 @@
-fileTypes: [
-  "lagda"
+'fileTypes': [
+  'lagda'
 ]
-name: "Literal Agda"
-patterns: [
+'name': 'Literate Agda'
+'scopeName': 'text.tex.latex.agda'
+'patterns': [
   {
-    begin: "\\b(module)\\s+([^\\(\\)\\{\\}[:space:]=→λ∀?][^\\(\\)\\{\\}[:space:]]*)\\b"
-    beginCaptures:
-      "1":
-        name: "keyword.other.agda"
-      "2":
-        name: "storage.module.agda"
-    end: "(\\bwhere\\b|=)"
-    endCaptures:
-      "1":
-        name: "keyword.other.agda"
-    name: "meta.declaration.module.agda"
-    patterns: [
+    'begin': '^((\\\\)begin)({)(code|spec)(})(\\s*\\n)?'
+    'beginCaptures':
+      '1':
+        'name': 'support.function.be.latex.agda'
+      '2':
+        'name': 'punctuation.definition.function.latex.agda'
+      '3':
+        'name': 'punctuation.definition.arguments.begin.latex.agda'
+      '5':
+        'name': 'punctuation.definition.arguments.end.latex.agda'
+    'end': '^((\\\\)end)({)\\4(})'
+    'endCaptures':
+      '1':
+        'name': 'support.function.be.latex.agda'
+      '2':
+        'name': 'punctuation.definition.function.latex.agda'
+      '3':
+        'name': 'punctuation.definition.arguments.begin.latex.agda'
+      '4':
+        'name': 'punctuation.definition.arguments.end.latex.agda'
+    'contentName': 'source.agda.embedded.latex.agda'
+    'name': 'meta.embedded.block.agda.latex.agda'
+    'patterns': [
       {
-        include: "#module_param"
-      }
-      {
-        include: "#module_params"
-      }
-      {
-        include: "#module_params_implicit"
-      }
-    ]
-  }
-  {
-    begin: "^\\s*(import|open(\\s+import)?)\\b"
-    beginCaptures:
-      "1":
-        name: "keyword.other.agda"
-    end: "$"
-    name: "meta.import.agda"
-    patterns: [
-      {
-        match: "\\b(as|using|renaming|hiding|public)\\b"
-        name: "keyword.other.agda"
+        'include': 'source.agda'
       }
     ]
   }
   {
-    begin: "^\\s*(record)\\s+([^\\(\\)\\{\\}[:space:]=→λ∀?][^\\(\\)\\{\\}[:space:]]*)\\b"
-    beginCaptures:
-      "1":
-        name: "keyword.other.agda"
-      "2":
-        name: "storage.record.agda"
-    end: "\\b(where)\\b"
-    endCaptures:
-      "1":
-        name: "keyword.other.agda"
-    name: "meta.declaration.record.agda"
-    patterns: []
+    'match': '(?<!\\\\verb)\\|((:?[^|]|\\|\\|)+)\\|'
+    'name': 'meta.embedded.text.agda.latex.agda'
+    'captures':
+      '1':
+        'patterns': [
+          {
+            'include': 'source.agda'
+          }
+        ]
   }
   {
-    begin: "\\b(data)\\s+([^\\(\\)\\{\\}[:space:]=→λ∀?][^\\(\\)\\{\\}[:space:]]*)\\b"
-    beginCaptures:
-      "1":
-        name: "keyword.other.agda"
-      "2":
-        name: "storage.data.agda"
-    end: "\\b(where)\\b"
-    endCaptures:
-      "1":
-        name: "keyword.other.agda"
-    name: "meta.declaration.record.agda"
-    patterns: []
-  }
-  {
-    begin: "\""
-    end: "\""
-    name: "string.quoted.double.agda"
-    patterns: [
-      {
-        match: "\\\\."
-        name: "constant.character.escape.agda"
-      }
-    ]
-  }
-  {
-    match: "\\binfix[lr]\\b"
-    name: "keyword.operator.agda"
-  }
-  {
-    match: "\\b(where|as|case|field|constructor|record|private|public|abstract|mutual)\\b"
-    name: "keyword.other.agda"
-  }
-  {
-    match: "(?<=\\s)[=→λ∀?]"
-    name: "keyword.operator.agda"
-  }
-  {
-    captures:
-      "1":
-        name: "entity.name.function.agda"
-      "2":
-        name: "keyword.other.colon.agda"
-    match: "^\\s*([^\\(\\)\\{\\}[:space:]=→λ∀?][^\\(\\)\\{\\}[:space:]]*)\\s*(:)(?=\\s|$)"
-    name: "meta.function.type-declaration.agda"
-  }
-  {
-    begin: "\""
-    beginCaptures:
-      "0":
-        name: "punctuation.definition.string.begin.agda"
-    end: "\""
-    endCaptures:
-      "0":
-        name: "punctuation.definition.string.end.agda"
-    name: "string.quoted.double.agda"
-    patterns: [
-      {
-        match: "\\\\(NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL|[abfnrtv\\\\\\\"'\\&])"
-        name: "constant.character.escape.agda"
-      }
-      {
-        match: "\\\\o[0-7]+|\\\\x[0-9A-Fa-f]+|\\\\[0-9]+"
-        name: "constant.character.escape.octal.agda"
-      }
-      {
-        match: "\\^[A-Z@\\[\\]\\\\\\^_]"
-        name: "constant.character.escape.control.agda"
-      }
-    ]
-  }
-  {
-    match: "\\b([0-9]+|0([xX][0-9a-fA-F]+))\\b"
-    name: "constant.numeric.agda"
-  }
-  {
-    include: "#dashComment"
-  }
-  {
-    include: "#pragma"
-  }
-  {
-    include: "#blockComment"
+    'include': 'text.tex.latex'
   }
 ]
-repository:
-  blockComment:
-    begin: "{-"
-    captures:
-      "0":
-        name: "punctuation.definition.comment.agda"
-    end: "-}"
-    name: "comment.block.agda"
-  dashComment:
-    begin: "(--)"
-    beginCaptures:
-      "0":
-        name: "punctuation.definition.comment.agda"
-    end: "$"
-    name: "comment.line.double-dash.agda"
-  identifier:
-    comment: "not so much here to be used as to be a reference"
-    match: "\\b[^\\(\\)\\{\\}[:space:]=→λ∀?][^\\(\\)\\{\\}[:space:]]*"
-    name: "entity.name.function.agda"
-  module_param:
-    match: "\\b[^\\(\\)\\{\\}[:space:]=→λ∀?][^\\(\\)\\{\\}[:space:]]*"
-    name: "entity.name.parameter.agda"
-  module_params:
-    begin: "\\("
-    end: "\\)"
-    name: "meta.declaration.module.params.agda"
-    patterns: [
-      {
-        include: "#module_param"
-      }
-      {
-        include: "#type_sig_rhs"
-      }
-    ]
-  module_params_implicit:
-    begin: "\\{"
-    end: "\\}"
-    name: "meta.declaration.module.params.agda"
-    patterns: [
-      {
-        include: "#module_param"
-      }
-      {
-        include: "#type_sig_rhs"
-      }
-    ]
-  pragma:
-    applyEndPatternLast: 1
-    begin: "\\{-#"
-    captures:
-      "0":
-        name: "punctuation.definition.pragma.agda"
-    end: "#-\\}"
-    name: "support.pragma.block.agda"
-  type_sig_rhs:
-    begin: ":"
-    end: "(?=[\\)\\}])"
-    name: "meta.declaration.module.params.typesig.agda"
-    patterns: [
-      {
-        match: "\\b[^\\(\\)\\{\\}[:space:]=→λ∀?][^\\(\\)\\{\\}[:space:]]*"
-        name: "storage.type.agda"
-      }
-    ]
-scopeName: "source.lagda"

--- a/grammars/lagda.cson
+++ b/grammars/lagda.cson
@@ -1,50 +1,50 @@
-'fileTypes': [
+fileTypes: [
   'lagda'
 ]
-'name': 'Literate Agda'
-'scopeName': 'text.tex.latex.agda'
-'patterns': [
+name: 'Literate Agda'
+scopeName: 'text.tex.latex.agda'
+patterns: [
   {
-    'begin': '^((\\\\)begin)({)(code|spec)(})(\\s*\\n)?'
-    'beginCaptures':
+    begin: '^((\\\\)begin)({)(code|spec)(})(\\s*\\n)?'
+    beginCaptures:
       '1':
-        'name': 'support.function.be.latex.agda'
+        name: 'support.function.be.latex.agda'
       '2':
-        'name': 'punctuation.definition.function.latex.agda'
+        name: 'punctuation.definition.function.latex.agda'
       '3':
-        'name': 'punctuation.definition.arguments.begin.latex.agda'
+        name: 'punctuation.definition.arguments.begin.latex.agda'
       '5':
-        'name': 'punctuation.definition.arguments.end.latex.agda'
-    'end': '^((\\\\)end)({)\\4(})'
-    'endCaptures':
+        name: 'punctuation.definition.arguments.end.latex.agda'
+    end: '^((\\\\)end)({)\\4(})'
+    endCaptures:
       '1':
-        'name': 'support.function.be.latex.agda'
+        name: 'support.function.be.latex.agda'
       '2':
-        'name': 'punctuation.definition.function.latex.agda'
+        name: 'punctuation.definition.function.latex.agda'
       '3':
-        'name': 'punctuation.definition.arguments.begin.latex.agda'
+        name: 'punctuation.definition.arguments.begin.latex.agda'
       '4':
-        'name': 'punctuation.definition.arguments.end.latex.agda'
-    'contentName': 'source.agda.embedded.latex.agda'
-    'name': 'meta.embedded.block.agda.latex.agda'
-    'patterns': [
+        name: 'punctuation.definition.arguments.end.latex.agda'
+    contentName: 'source.agda.embedded.latex.agda'
+    name: 'meta.embedded.block.agda.latex.agda'
+    patterns: [
       {
         'include': 'source.agda'
       }
     ]
   }
   {
-    'match': '(?<!\\\\verb)\\|((:?[^|]|\\|\\|)+)\\|'
-    'name': 'meta.embedded.text.agda.latex.agda'
-    'captures':
+    match: '(?<!\\\\verb)\\|((:?[^|]|\\|\\|)+)\\|'
+    name: 'meta.embedded.text.agda.latex.agda'
+    captures:
       '1':
-        'patterns': [
+        patterns: [
           {
-            'include': 'source.agda'
+            include: 'source.agda'
           }
         ]
   }
   {
-    'include': 'text.tex.latex'
+    include: 'text.tex.latex'
   }
 ]


### PR DESCRIPTION
This PR sets the grammar scope for literate Agda to be `text.tex.latex.agda`, includes the `text.tex.latex` grammar and then only uses `source.agda` in code and verbatim blocks. This is in line with how [language-haskell](https://atom.io/packages/language-haskell) and [language-knitr](https://atom.io/packages/language-knitr) function, plus it makes the key bindings for [latex](https://atom.io/packages/latex) function correctly.