### PR TITLE
Fix typo

### DIFF
--- a/grammars/tree-sitter-agda.cson
+++ b/grammars/tree-sitter-agda.cson
@@ -41,7 +41,7 @@ scopes:
     'source_file': 'source.agda'
 
     # puctuations
-    '"="': 'punctuation.binging.agda'
+    '"="': 'punctuation.binding.agda'
     '":"': 'punctuation.colon.agda'
     '"→"': 'punctuation.arrow.agda'
     '"->"': 'punctuation.arrow.agda'


### PR DESCRIPTION
Hey, I'm assuming that `binging` is a typo.

By the way, I'm also wondering why Atom doesn't seem to colour `punctuation.X` entities differently? I think it would be a bit nicer if type signatures weren't so monochrome.